### PR TITLE
week24 fix

### DIFF
--- a/homeworks/week24/fe/hw1/src/App.js
+++ b/homeworks/week24/fe/hw1/src/App.js
@@ -5,7 +5,7 @@ import './App.css';
 import Nav from './container/navTabContainer'
 import Footer from './components/footer/footer.js'
 import Share from './container/shareContainer'
-import Home from './components/home'
+import Home from './container/HomeContainer'
 import Edit from './container/editContainer.js'
 import PostList from './container/postListContainer'
 import Post from './container/postContainer'

--- a/homeworks/week24/fe/hw1/src/WebAPI.js
+++ b/homeworks/week24/fe/hw1/src/WebAPI.js
@@ -1,7 +1,8 @@
 import axios from 'axios';
 
+export const getUnsplashPosts = () => axios.get('https://api.unsplash.com/photos/?client_id=aae4b30df237a7474cc5ff86eca6fd20ff9c173db667d16b8958205a6948fab4&per_page=30')
 export const getPosts = () => axios.get('https://qootest.com/posts?_sort=id&_order=desc&_limit=10')
 export const getSinglePost = (postId) => axios.get(`https://qootest.com/posts/${postId}`)
 export const deletePost = postId => axios.delete(`https://qootest.com/posts/${postId}`)
-export const sharePost = (post) => axios.post('https://qootest.com/posts', post)
-export const editPost = (postId, post) => axios.put(`https://qootest.com/posts/${postId}`, post)
+export const sharePost = (title, author, body) => axios.post('https://qootest.com/posts', { title, author, body })
+export const editPost = (postId, title, author, body) => axios.put(`https://qootest.com/posts/${postId}`, {title, author, body})

--- a/homeworks/week24/fe/hw1/src/action.js
+++ b/homeworks/week24/fe/hw1/src/action.js
@@ -9,6 +9,13 @@ export const updateNavTab = (tab) => {
     }
 }
 
+export const getUnsplashPostList = () => {
+    return {
+        type: 'GET_UNSPLASH_POST_LIST',
+        payload: WebAPI.getUnsplashPosts()
+    }
+}
+
 export const getPostList = () => {
     return {
         type: 'GET_POST_LIST',
@@ -30,16 +37,16 @@ export const DeletePost = (postId) => {
     }
 }
 
-export const ShareSinglePost = (post) => {
+export const ShareSinglePost = (title, author, body) => {
     return {
         type: 'SHARE_POST',
-        payload: WebAPI.sharePost(post)
+        payload: WebAPI.sharePost(title, author, body)
     }
 }
 
-export const EditSinglePost = (postId, post) => {
+export const EditSinglePost = (postId, title, author, body) => {
     return {
         type: 'EDIT_POST',
-        payload: WebAPI.editPost(postId, post)
+        payload: WebAPI.editPost(postId, title, author, body)
     }
 }

--- a/homeworks/week24/fe/hw1/src/components/edit/index.js
+++ b/homeworks/week24/fe/hw1/src/components/edit/index.js
@@ -5,36 +5,24 @@ import {
     Link
 } from "react-router-dom"
 import FontAwesome from 'react-fontawesome';
-import { editPost, getSinglePost } from '../../WebAPI'
 
 class Edit extends Component {
     constructor(props) {
         super(props)
         this.state = {
-            id: '',
-            author: '',
             title: '',
-            body: ''
+            author: '',
+            body: '',
         }
     }
 
     componentDidMount() {
         const postId = this.props.match.params.id
-        getSinglePost(postId)
-            .then(resp => {
-                this.setState({
-                    id: resp.data.id,
-                    author: resp.data.author,
-                    title: resp.data.title,
-                    body: resp.data.body
-                })
-            })
-            .catch(error => console.log(error))
+        this.props.getSinglePost(postId)
     }
 
-    //這邊已經可以拿掉變更後的值. 
     handleChange = (e) => {
-        const { author, title, body } = this.state
+        const { title, author, body } = this.state
         this.setState({
             [e.target.name]: e.target.value
         })
@@ -42,21 +30,17 @@ class Edit extends Component {
 
 
     onConfirm = () => {
-        const { author, title, body } = this.state
         const postId = this.props.match.params.id
-        const post = { author, title, body }
-        this.props.editPost(postId, post)
-
-        this.setState({
-            author: '',
-            title: '',
-            body: ''
-        })
+        const {title, author, body} = this.state
+        this.props.editPost(postId, title, author, body)
     }
 
-    // 這樣做速度會快於api, race condition....
     componentDidUpdate(prevProps) {
-        const { isLoadingEditPost, history } = this.props
+        const { post, isLoadingEditPost, history } = this.props
+        if (post !== prevProps.post){ 
+            this.handlePropsToState();
+        }
+
         if (
             isLoadingEditPost !== prevProps.isLoadingEditPost && !isLoadingEditPost
         ) {
@@ -64,10 +48,19 @@ class Edit extends Component {
         } 
     }
 
+    handlePropsToState=() =>{
+        const {post} = this.props
+        this.setState({
+            title: post.title,
+            author: post.author,
+            body: post.body
+        })
+    }
+
 
 
     render() {
-        const { author, title, body } = this.state
+        const { title, author, body } = this.state
         const style = {
             height: '300px'
         }

--- a/homeworks/week24/fe/hw1/src/components/home/index.js
+++ b/homeworks/week24/fe/hw1/src/components/home/index.js
@@ -16,46 +16,32 @@ const Img = ({ src, desc, link }) => {
 
 
 class Home extends Component {
-    constructor() {
-        super()
-        this.state = {
-            pictures: [],
-            isLoading: true
-        }
-    }
-
     componentDidMount() {
-        const { pictures } = this.state
-        const url = "https://api.unsplash.com/photos/" + "?client_id=aae4b30df237a7474cc5ff86eca6fd20ff9c173db667d16b8958205a6948fab4" + "&per_page=30";
-        axios.get(url)
-        //.then(res => console.log(res))
-        axios.get(url)
-            .then(res => {
-                this.setState({
-                    pictures: res.data,
-                    isLoading: false
-                })
-            })
-
+        this.props.getUnsplashPostList()
     }
 
     render() {
-        const { pictures, isLoading} = this.state
+        const { isLoadingGetUnsplashPosts, UnsplashPosts } = this.props
         const template =(
             <div className="wrapper">
-                {pictures.map(picture =>
+                {UnsplashPosts.map(UnsplashPost =>
                     <div className="row">
                         <div className="col">
-                            <Img src={picture.urls.small} desc={picture.alt_description} link={picture.links.html}/>
+                            <Img src={UnsplashPost.urls.small} desc={UnsplashPost.alt_description} link={UnsplashPost.links.html}/>
                             </div>
                     </div>
                 )}
             </div>
         )
+        const loading = (
+            <div className="spinner-border" role="status">
+                <span className="sr-only">Loading...</span>
+            </div>
+        )
         return (
             <div>
                 <h1>Welcome</h1>
-                {isLoading ? <h4>Loading...</h4> : template}
+                {isLoadingGetUnsplashPosts ? loading : template}
             </div>
         )
     }

--- a/homeworks/week24/fe/hw1/src/components/post/index.js
+++ b/homeworks/week24/fe/hw1/src/components/post/index.js
@@ -16,13 +16,13 @@ class Item extends Component {
                 <div className="row">
                     <div className="col-3 info">
                         <span>Id</span>
-                        <p>{post.id}</p>
+                        <div>{post.id}</div>
                         <span>Author</span>
-                        <p>{post.author ? <ReactMarkdown source={post.author} />: '作者不詳'}</p>
+                        <div>{post.author ? <ReactMarkdown source={post.author} />: '作者不詳'}</div>
                         <span>Title</span>
-                        <p><ReactMarkdown source={post.title} /></p>
+                        <div><ReactMarkdown source={post.title} /></div>
                         <span>Created Time</span>
-                        <p className="createdTime">{post.createdAt ? post.createdAt : '無從得知'}</p>
+                        <div className="createdTime">{post.createdAt ? post.createdAt : '無從得知'}</div>
                     </div>
                     <div className="col-9 article">
                         <div className="content">

--- a/homeworks/week24/fe/hw1/src/components/share/index.js
+++ b/homeworks/week24/fe/hw1/src/components/share/index.js
@@ -8,8 +8,6 @@ import {
 
 import FontAwesome from 'react-fontawesome';
 
-
-
 class Share extends Component {
     constructor(props) {
         super(props)
@@ -24,7 +22,6 @@ class Share extends Component {
         const { isLoadingSharePost, history } = this.props
 
         if (
-            // 前面的loading不等於現在的loading且現在沒有在loading
             prevProps.isLoadingSharePost !== isLoadingSharePost && !isLoadingSharePost
         ) {
             history.push('/post')
@@ -42,9 +39,8 @@ class Share extends Component {
 
 
     onSubmit = () => {
-        const { author, title, body } = this.state
-        const post = { author, title, body }
-        this.props.sharePost(post)
+        const { title, author, body } = this.state
+        this.props.sharePost(title, author, body)
         this.setState({
             author: '',
             title: '',
@@ -54,6 +50,7 @@ class Share extends Component {
 
     render() {
         const { author, title, body } = this.state
+        console.log(author, title, body)
         const isLoadingSharePost = this.props
 
         const style = {

--- a/homeworks/week24/fe/hw1/src/container/HomeContainer.js
+++ b/homeworks/week24/fe/hw1/src/container/HomeContainer.js
@@ -1,0 +1,31 @@
+import React, { Component } from 'react';
+import { withRouter } from "react-router-dom";
+import { connect } from 'react-redux'
+import { getUnsplashPosts } from '../WebAPI'
+import * as action from '../action'
+import Home from '../components/home'
+
+const HomeContainer = (props) => {
+    return <Home {...props} />
+}
+
+const mapStateToProps = state => {
+    return {
+        isLoadingGetUnsplashPosts: state.nav.isLoadingGetUnsplashPosts,
+        UnsplashPosts: state.nav.UnsplashPosts
+    }
+}
+
+const mapDispatchToProps = dispatch => {
+    return {
+        getUnsplashPostList: () => {
+            dispatch(action.getUnsplashPostList())
+        }
+    }
+}
+
+
+export default
+    withRouter(
+        connect(mapStateToProps, mapDispatchToProps)(HomeContainer)
+    );

--- a/homeworks/week24/fe/hw1/src/container/editContainer.js
+++ b/homeworks/week24/fe/hw1/src/container/editContainer.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import '../components/post/post.css'
 import { withRouter } from "react-router-dom";
 import { connect } from 'react-redux'
-import { editPost } from '../WebAPI'
+import { editPost} from '../WebAPI'
 import * as action from '../action'
 import Edit from '../components/edit'
 
@@ -13,15 +13,19 @@ const editContainer = (props) => {
 
 const mapStateToProps = (state) =>{
     return{
-        isLoadingEditPost: state.nav.isLoadingEditPost
+        isLoadingEditPost: state.nav.isLoadingEditPost,
+        post:state.nav.post
     }
 }
 
 
 const mapDispatchToProps = dispatch => {
     return {
-        editPost: (postId, post) => {
-            dispatch(action.EditSinglePost(postId, post))
+        editPost: (postId, title, author, body) => {
+            dispatch(action.EditSinglePost(postId, title, author, body))
+        }, 
+        getSinglePost: (postId) => {
+            dispatch(action.SingleGetPost(postId))
         }
     }
 }

--- a/homeworks/week24/fe/hw1/src/container/shareContainer.js
+++ b/homeworks/week24/fe/hw1/src/container/shareContainer.js
@@ -20,8 +20,8 @@ const mapStateToProps = (state) =>{
 //重點就是這裡要實作改變
 const mapDispatchToProps = dispatch => {
     return {
-        sharePost: (post) => {
-            dispatch(action.ShareSinglePost(post))
+        sharePost: (title, author, body) => {
+            dispatch(action.ShareSinglePost(title, author, body))
         }
     }
 }

--- a/homeworks/week24/fe/hw1/src/reducer.js
+++ b/homeworks/week24/fe/hw1/src/reducer.js
@@ -2,11 +2,13 @@ import * as actionTypes from './actionTypes'
 
 const state = {
     navTab: 'Home',
+    isLoadingGetUnsplashPosts: false,
     isLoadingGetPosts: false,
     isLoadingGetPost: false,
     isLoadingDeletePost: false,
     isLoadingSharePost: false,
     isLoadingEditPost: false,
+    UnsplashPosts:[],
     posts: [],
     post: {},
 }
@@ -18,6 +20,19 @@ function reducer(globalState = state, action) {
             return {
                 ...globalState,
                 navTab: action.name
+            }
+
+        case 'GET_UNSPLASH_POST_LIST_PENDING':
+            return {
+                ...globalState,
+                isLoadingGetUnsplashPosts: true,
+            }
+
+        case 'GET_UNSPLASH_POST_LIST_FULFILLED':
+            return {
+                ...globalState,
+                isLoadingGetUnsplashPosts: false,
+                UnsplashPosts: action.payload.data
             }
 
         case 'GET_POST_LIST_PENDING':
@@ -56,7 +71,6 @@ function reducer(globalState = state, action) {
             return {
                 ...globalState,
                 isLoadingDeletePost: false,
-                //posts: state.posts.filter(post => post.id !== action.payload)
             }
 
         case 'SHARE_POST_PENDING':
@@ -69,7 +83,6 @@ function reducer(globalState = state, action) {
             return {
                 ...globalState,
                 isLoadingSharePost: false,
-                post: [...state.posts, action.payload]
             }
 
         case 'EDIT_POST_PENDING':
@@ -82,7 +95,6 @@ function reducer(globalState = state, action) {
             return {
                 ...globalState,
                 isLoadingEditPost: false,
-                post: [...state.posts, action.payload]
             }
 
         default:


### PR DESCRIPTION
### [Blog](https://fan630.github.io/Blog_Redux_promise/#/)
---

這次交作業太倉促了, 蠻多地方沒有用到redux-promise...
所以有如下修正

* unsplash 獲得圖片的方式改用redux-promise
* 修正WebAPI sharePost和editPost 傳送的參數
* 修正edit/share reducer, 並更改在components中拿取資料的方法

另外這次有發現在bootstrap有`spinners`的用法.  
所以把原本是顯示loading的字串改為轉圈圈的圖示. 

再麻煩老師費心了！ 謝謝！！